### PR TITLE
Add basic Linux/macOS support

### DIFF
--- a/avsViewer.cpp
+++ b/avsViewer.cpp
@@ -1,5 +1,14 @@
 #include "avsViewer.h"
-#include <conio.h>
+#ifdef _WIN32
+    #include <conio.h>
+    #define AVISYNTH_LIB "AviSynth.dll"
+#else
+    #ifdef __APPLE__
+        #define AVISYNTH_LIB "libavisynth.dylib"
+    #else
+        #define AVISYNTH_LIB "libavisynth.so"
+    #endif
+#endif
 #include <QFile>
 #include <QPixmap>
 #include <iostream>
@@ -50,9 +59,9 @@ avsViewer::avsViewer(QWidget *parent, const QString& path, const double& mult, c
   m_desktopHeight = height;
   std::cout << "-> using desktop resolution: " << m_desktopWidth << "x" << m_desktopHeight << std::endl;
   ui.scrollArea->setWidget(m_showLabel);
-  QString avisynthDll = QDir::toNativeSeparators(qApp->applicationDirPath() + QDir::separator() + QString("AviSynth.dll"));
+  QString avisynthDll = QDir::toNativeSeparators(qApp->applicationDirPath() + QDir::separator() + QString(AVISYNTH_LIB));
   if (!QFile::exists(avisynthDll)) {
-    avisynthDll = QString("AviSynth.dll");
+    avisynthDll = QString(AVISYNTH_LIB);
   }
   m_avsDLL.setFileName(avisynthDll);
   if (m_currentInput.isEmpty()) {
@@ -98,10 +107,10 @@ bool avsViewer::loadAvisynthDLL()
   if (!m_avsDLL.load()) {
     QString error = m_avsDLL.errorString();
     if (!error.isEmpty()) {
-      std::cerr << "Could not load avisynth.dll! " << std::endl << qPrintable(error) << std::endl;
+      std::cerr << "Could not load " AVISYNTH_LIB "! " << std::endl << qPrintable(error) << std::endl;
       return false;
     }
-    std::cerr << "Could not load avisynth.dll!" << std::endl;
+    std::cerr << "Could not load " AVISYNTH_LIB "!" << std::endl;
     return false;
   }
   std::cout << "loaded avisynth dll,..(" << qPrintable(m_avsDLL.fileName()) << ")" << std::endl;

--- a/avsViewer.pro
+++ b/avsViewer.pro
@@ -6,13 +6,19 @@ CONFIG += console
 
 UI_DIR = uiHeaders
 TEMPLATE = app
-contains(QMAKE_TARGET.arch, x86_64) {
-  message("64bit build")
+win32* {
+    contains(QMAKE_TARGET.arch, x86_64) {
+      message("64bit build")
+      CODECFORSRC = UTF-8
+      CODECFORTR = UTF-8
+      TARGET = avsViewer64
+    } else {
+      message("32bit build")
+      TARGET = avsViewer
+    }
+} else {
   CODECFORSRC = UTF-8
   CODECFORTR = UTF-8
-  TARGET = avsViewer64
-} else {
-  message("32bit build")
   TARGET = avsViewer
 }
 
@@ -87,5 +93,9 @@ SOURCES += LocalSocketIpcServer.cpp \
 FORMS += viewer.ui
 RESOURCES +=
 
-
-INCLUDEPATH += "C:\Program Files (x86)\AviSynth+\FilterSDK\include"
+win32* {
+    INCLUDEPATH += "C:\Program Files (x86)\AviSynth+\FilterSDK\include"
+} else {
+    INCLUDEPATH += "/usr/include/avisynth"
+    INCLUDEPATH += "/usr/local/include/avisynth"
+}


### PR DESCRIPTION
I was curious, so after installing Qt6, I went about compiling on Ubuntu 22.10.

The changes amount to:
* Instances of `AviSynth.dll` changed to generic `AVISYNTH_LIB` macro that subs in the correct library name on the OS, since on macOS and Linux the name is `libavisynth` with either `dylib` or `so` file extension.
* Guarding a single Win32 header (`conio.h`)
* Adjusting the initial `QMAKE_TARGET.arch` area for non-Windows.  Whether `CODECFORSRC` and `CODECFORTR` are really necessary is questionable, I guess?  And that on *nix, it'll just build in 64-bit or 32-bit if that's what the OS itself is; there's little reason for AviSynth+ to even be built in a multilib environment anywhere but Windows.
* Making sure it can find the standard install paths for the headers, either in `/usr` or `/usr/local`.
